### PR TITLE
fix: Correct typos

### DIFF
--- a/healthcare.owl
+++ b/healthcare.owl
@@ -52,9 +52,9 @@
     
 
 
-    <!-- http://www.semanticweb.org/chenxixu/ontologies/2023/9/untitled-ontology-29#hasAlzheimer -->
+    <!-- http://www.semanticweb.org/chenxixu/ontologies/2023/9/untitled-ontology-29#hasAlzheimers -->
 
-    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/chenxixu/ontologies/2023/9/untitled-ontology-29#hasAlzheimer">
+    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/chenxixu/ontologies/2023/9/untitled-ontology-29#hasAlzheimers">
         <rdfs:subPropertyOf rdf:resource="http://www.semanticweb.org/chenxixu/ontologies/2023/9/untitled-ontology-29#hasDisease"/>
         <rdfs:domain rdf:resource="http://www.semanticweb.org/chenxixu/ontologies/2023/9/untitled-ontology-29#Diseases"/>
         <rdfs:range rdf:resource="http://www.semanticweb.org/chenxixu/ontologies/2023/9/untitled-ontology-29#Alzheimers"/>

--- a/healthcare.properties
+++ b/healthcare.properties
@@ -1,4 +1,4 @@
-#Sun Oct 29 23:57:41 MST 2023
+#Mon Oct 30 01:44:49 MST 2023
 jdbc.password=
 jdbc.user=
 jdbc.url=


### PR DESCRIPTION
**Known Issue:**

- Typos for Alzheimer's Disease and hasAlzheimer property

**This PR Introduces:**

- Renaming the object and property to Alzheimers and hasAlzheimers respectively